### PR TITLE
Change the method of calculating bitmask in register component function

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -27,9 +27,8 @@ pub struct Entities {
 impl Entities {
     pub fn register_component<T: Any + 'static>(&mut self) {
         let type_id = TypeId::of::<T>();
-        let bit_mask = 2u32.pow(self.bit_masks.len() as u32);
         self.components.insert(type_id, vec![]);
-        self.bit_masks.insert(type_id, bit_mask);
+        self.bit_masks.insert(type_id, 1 << self.bit_masks.len());
     }
 
     pub fn create_entity(&mut self) -> &mut Self {


### PR DESCRIPTION
Change the ugly 2_u32 to the power of sth as u32 to the bit shifting method in Entities register component function. It looks better and is about 6.8% faster than the old one. It was measured by the following benchmark:
```
let mut world = World::new();
for _ in 0..25{
    world.register_component::<A>();
}
struct A{}
```